### PR TITLE
Refactor: Centralize permission checking and fix tests

### DIFF
--- a/src/main/java/com/example/iamsystem/aspect/AuthorizationAspect.java
+++ b/src/main/java/com/example/iamsystem/aspect/AuthorizationAspect.java
@@ -19,9 +19,8 @@ public class AuthorizationAspect {
 
     @Before("@annotation(requirePermission)")
     public void checkPermission(JoinPoint joinPoint, RequirePermission requirePermission) {
-        DefaultUserDetails userDetails = (DefaultUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        if (!permissionService.hasPermission(userDetails.getUser(), requirePermission.serviceName()+":"+requirePermission.action())) {
+        String requiredPermission = requirePermission.serviceName() + ":" + requirePermission.action();
+        if (!permissionService.hasPermission(requiredPermission)) {
             throw new NoAccessException("User does not have permission to perform this action");
         }
     }

--- a/src/main/java/com/example/iamsystem/permission/PermissionService.java
+++ b/src/main/java/com/example/iamsystem/permission/PermissionService.java
@@ -6,9 +6,11 @@ import com.example.iamsystem.permission.model.Permission;
 import com.example.iamsystem.permission.model.PermissionAction;
 import com.example.iamsystem.permission.model.PermissionDto;
 import com.example.iamsystem.permission.model.PermissionMapper;
+import com.example.iamsystem.security.user.DefaultUserDetails;
 import com.example.iamsystem.user.model.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.mapstruct.factory.Mappers;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -63,7 +65,9 @@ public class PermissionService {
         return permissionMapper.toDto(permissionRepository.findAll());
     }
 
-    public boolean hasPermission(User user, String requiredPermission) {
+    public boolean hasPermission(String requiredPermission) {
+        DefaultUserDetails userDetails = (DefaultUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        User user = userDetails.getUser();
         if(user.isRootUser()) return true;
         return user.getRoles().stream()
                 .flatMap(role -> role.getPermissions().stream())

--- a/src/main/java/com/example/iamsystem/security/controller/AuthController.java
+++ b/src/main/java/com/example/iamsystem/security/controller/AuthController.java
@@ -2,7 +2,7 @@ package com.example.iamsystem.security.controller;
 
 import com.example.iamsystem.constant.ErrorMessage;
 import com.example.iamsystem.exception.JwtException;
-import com.example.iamsystem.permission.model.PermissionAction;
+import com.example.iamsystem.permission.PermissionService;
 import com.example.iamsystem.security.dto.AuthorizationRequest;
 import com.example.iamsystem.security.dto.AuthorizationResponse;
 import com.example.iamsystem.security.dto.JwtRefreshTokenDto;
@@ -10,6 +10,7 @@ import com.example.iamsystem.security.dto.JwtResponse;
 import com.example.iamsystem.security.dto.TokenValidationRequest;
 import com.example.iamsystem.security.dto.TokenValidationResponse;
 import com.example.iamsystem.security.jwt.JwtTokenUtil;
+import com.example.iamsystem.security.user.DefaultUserDetails;
 import com.example.iamsystem.security.user.DefaultUserDetailsService;
 import com.example.iamsystem.user.model.dto.UserLoginDto;
 import jakarta.validation.Valid;
@@ -36,6 +37,7 @@ public class AuthController {
     private final AuthenticationManager authenticationManager;
     private final DefaultUserDetailsService userDetailsService;
     private final JwtTokenUtil jwtTokenUtil;
+    private final PermissionService permissionService;
 
 
     @PostMapping("/authenticate")
@@ -64,14 +66,9 @@ public class AuthController {
 
     @PostMapping("/authorize")
     public ResponseEntity<AuthorizationResponse> authorize(@Valid @RequestBody AuthorizationRequest authorizationRequest) {
-        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        boolean permission = hasPermission(userDetails, authorizationRequest.getServiceName(), PermissionAction.valueOf(authorizationRequest.getAction()));
+        String requiredPermission = authorizationRequest.getServiceName() + ":" + authorizationRequest.getAction();
+        boolean permission = permissionService.hasPermission(requiredPermission);
         return ResponseEntity.ok(new AuthorizationResponse(permission));
-    }
-
-    private static boolean hasPermission(UserDetails userDetails, String serviceName, PermissionAction action) {
-        return userDetails.getAuthorities().stream()
-                .anyMatch(authority -> authority.getAuthority().equals(serviceName + ":" + action));
     }
 
     private JwtResponse getTokens(UserDetails userDetails, String username) {

--- a/src/main/java/com/example/iamsystem/user/UserService.java
+++ b/src/main/java/com/example/iamsystem/user/UserService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.mapstruct.factory.Mappers;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -133,7 +134,7 @@ public class UserService {
         if(Objects.isNull(user)) {
             throw new NoAccessException(NO_PERMISSION);
         }
-        boolean hasPermission = permissionService.hasPermission(user, requiredPermission);
+        boolean hasPermission = permissionService.hasPermission(requiredPermission);
         if (!hasPermission) {
             throw new NoAccessException(NO_PERMISSION);
         }

--- a/src/test/java/com/example/iamsystem/user/UserServiceTest.java
+++ b/src/test/java/com/example/iamsystem/user/UserServiceTest.java
@@ -146,7 +146,7 @@ class UserServiceTest {
         mockSecurityContext(user);
         when(passwordEncoder.encode(anyString())).thenReturn("encoded_password");
         user.setCreatedBy(user);
-        when(permissionService.hasPermission(any(User.class), anyString())).thenReturn(true);
+        when(permissionService.hasPermission(anyString())).thenReturn(true);
         when(userRepository.save(any(User.class))).thenReturn(user);
 
         // Act
@@ -212,7 +212,7 @@ class UserServiceTest {
         userRegistrationDto.setRootUser(false);
 
         mockSecurityContext(user); // user logged in
-        when(permissionService.hasPermission(any(User.class), anyString())).thenReturn(false);
+        when(permissionService.hasPermission(anyString())).thenReturn(false);
         doNothing().when(userValidator).validateUsernameAvailable(anyString());
         doNothing().when(userValidator).validateEmailAvailable(anyString());
 
@@ -228,7 +228,7 @@ class UserServiceTest {
         userRoleAttachmentDto.setUsername("testUser");
         Set<Long> roleIds = Set.of(1L);
         userRoleAttachmentDto.setRoleIds(roleIds);
-        when(permissionService.hasPermission(any(User.class), anyString())).thenReturn(true);
+        when(permissionService.hasPermission(anyString())).thenReturn(true);
         when(userRepository.findByUsername(anyString())).thenReturn(Optional.ofNullable(user));
         when(userRoleAttachmentUtil.validateAndRetrieveRoles(anySet())).thenReturn(roles);
         when(userRepository.save(any(User.class))).thenReturn(user);
@@ -298,7 +298,7 @@ class UserServiceTest {
         userRoleAttachmentDto.setUsername("testUser");
         Set<Long> roleIds = Set.of(1L);
         userRoleAttachmentDto.setRoleIds(roleIds);
-        when(permissionService.hasPermission(any(User.class), anyString())).thenReturn(true);
+        when(permissionService.hasPermission(anyString())).thenReturn(true);
         when(userRepository.findByUsername(anyString())).thenReturn(Optional.ofNullable(user));
         doThrow(new DataNotFoundException("Some roles not found")).when(userRoleAttachmentUtil).validateAndRetrieveRoles(anySet());
 
@@ -314,7 +314,7 @@ class UserServiceTest {
         userRoleAttachmentDto.setUsername("testUser");
         userRoleAttachmentDto.setRoleIds(Set.of(1L));
 
-        when(permissionService.hasPermission(any(User.class), anyString())).thenReturn(true);
+        when(permissionService.hasPermission(anyString())).thenReturn(true);
         when(userRepository.findByUsername(anyString())).thenReturn(Optional.of(user));
         when(userRoleAttachmentUtil.validateAndRetrieveRoles(anySet())).thenReturn(roles);
 


### PR DESCRIPTION
- Modified AuthController.authorize to use PermissionService.hasPermission.
- Fixed PermissionServiceTest to correctly mock SecurityContextHolder and User/Role behavior.
- Adjusted UserServiceTest to align with PermissionService.hasPermission signature.